### PR TITLE
[#4] Setting the layout property causes the component template to not render with Ember 1.13

### DIFF
--- a/addon/components/image-cropper.js
+++ b/addon/components/image-cropper.js
@@ -2,8 +2,6 @@ import Ember from 'ember';
 import layout from '../templates/components/image-cropper';
 
 export default Ember.Component.extend({
-  layout: layout,
-
   //cropper configs
   previewClass: '.cropper-preview',
   cropperContainer: '.cropper-container > img',


### PR DESCRIPTION
I don't know the original intention behind setting the layout property, but removing it solves the issue.