### PR TITLE
Fix version of ember cli htmlbars

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-cli-htmlbars": "0.7.4"
+    "ember-cli-htmlbars": "^1.0.8"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Ember cli image cropper throws out deprecation notes due to the fact that it uses old version of HTMLBars. Please update it to the newest version and make a new release tag and the issue we be solved.

> DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-htmlbars`
  at Function.Addon.lookup (/Users/estshy/enquicken/site/node_modules/ember-cli/lib/models/addon.js:896:27)