### PR TITLE
Fixes to ember-cli-htmlbars deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-cli-htmlbars": "0.7.4"
+    "ember-cli-htmlbars": "1.0.11"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-htmlbars`. Could you please take a look at this issue and merge this PR in?

```
├── ember-cli-htmlbars@1.0.11 
├─┬ ember-cli-image-cropper@0.0.8
│ └── ember-cli-htmlbars@0.7.4 
├─┬ ember-cli-spinner@0.0.7
│ └── ember-cli-htmlbars@0.7.9 
└─┬ ember-modal-dialog@0.8.3
  └── ember-cli-htmlbars@0.7.9 
```