### PR TITLE
Update for ember 2.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
-    "ember-cli-htmlbars": "1.0.11"
+    "ember-cli-htmlbars": "^1.0.11"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Running ember-cli-image-cropper with ember 2.11.0 will break as ember may now be fetched through npm rather than bower ( #18 related ). Need to bump the version of ember-cli-htmlbars.