### PR TITLE
added data prop for defaulting crop data

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ dragMove: null,
 dragEnd: null,
 zoomin: null,
 zoomout: null,
-ready: null
+ready: null,
+data: null
 ```
 For more options and methods, please check cropper's [README](https://github.com/fengyuanchen/cropper#options_).

--- a/addon/components/image-cropper.js
+++ b/addon/components/image-cropper.js
@@ -40,6 +40,7 @@ export default Ember.Component.extend({
   zoomin: null,
   zoomout: null,
   ready: null,
+  data: null,
   //initialize cropper on did insert element
   didInsertElement(){
     this._super(...arguments);
@@ -81,6 +82,7 @@ export default Ember.Component.extend({
       'zoomin',
       'zoomout',
       'ready',
+      'data'
     );
     properties['preview'] = properties['previewClass'];
     delete properties['previewClass'];


### PR DESCRIPTION
I noticed I wasn't able to preset crop data when the component initialized and had to use `.setData` with a setTimeout in order to see my previous crop on an image I reloaded.  

This update just passes along the data property to cropperjs to use as the initial crop points.  